### PR TITLE
🔀 Monitoring dashboard chart 사이즈 조절 & 페이지 Route로 구분

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -41,7 +41,7 @@ function App() {
           <Route path="/cd/dashboard" element={isLogin ? <CDDashboard /> : <Navigate to={"/"} />} />
           <Route path="/cd/repoList" element={isLogin ? <RepoList /> : <Navigate to={"/"} />} />
           <Route path="/monitoring/clusterList" element={isLogin ? <ClusterList /> : <Navigate to={"/"} />} />
-          <Route path="/monitoring/dashboard" element={isLogin ? <MonitoringDashboard /> : <Navigate to={"/"} />} />
+          <Route path="/monitoring/dashboard/*" element={isLogin ? <MonitoringDashboard /> : <Navigate to={"/"} />} />
           <Route path="/monitoring/token" element={isLogin ? <Token /> : <Navigate to={"/"} />} />
         </Routes>
         <Nav open={navOpen}/>

--- a/src/components/formtoyaml/FormToYamlFooter.jsx
+++ b/src/components/formtoyaml/FormToYamlFooter.jsx
@@ -122,7 +122,7 @@ function FormToYamlFooter(props) {
             if (isExpanded) {
                 if (yaml && repository && branches && commitMessage && fileName) {
                     axios
-                        .post(`/api/v1/users/github-repo/${repository}/${branch.replace("/", " ")}`,
+                        .post(`/api/v1/users/github-repo/${repository.replace("/", " ")}/${branch.replace("/", " ")}`,
                             {
                                 "yaml": yaml,
                                 "file_name": fileName.endsWith(".yaml") ? fileName : fileName + ".yaml",

--- a/src/components/monitoring/Chart.jsx
+++ b/src/components/monitoring/Chart.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ApexChart from 'react-apexcharts';
 import { RadialBar } from 'apexcharts';
 
-const Chart = ({ title, values, fullValue }) => {
+const Chart = ({ title, values, fullValue, colors }) => {
 
     const series = values.map(item => item.value/fullValue * 100);
 
@@ -13,7 +13,7 @@ const Chart = ({ title, values, fullValue }) => {
             height: 250, // Set chart height to 250 pixels
             aspectRatio: 4, // Maintain a 2:1 aspect ratio
         },
-        colors: ['#019CF6', '#256CD6'],
+        colors: colors,
         plotOptions: {
             radialBar: {
                 inverseOrder: false,
@@ -61,7 +61,6 @@ const Chart = ({ title, values, fullValue }) => {
             position: 'bottom',
             horizontalAlign: 'left',
             formatter: function(seriesName, opts) {
-                console.log(opts);
                 if (opts.seriesIndex < series.length) return `
                     <div class="legend-item-label">${seriesName}</div>
                     <div class="legend-item-value">${values[opts.seriesIndex].value}</div>
@@ -88,14 +87,14 @@ const Chart = ({ title, values, fullValue }) => {
     }
 
     return (
-        <div className="chart-container">
+        <div className="chart-container" style={{ width: '230px', height: '300px'}}>
             <p className="chart-title">{title}</p>
             <ApexChart
                 options={options}
                 series={series}
                 type="radialBar"
-                width={288}
-                height={302}
+                width='100%'
+                height='100%'
                 />
         </div>
     );

--- a/src/components/monitoring/MonitoringNav.jsx
+++ b/src/components/monitoring/MonitoringNav.jsx
@@ -6,6 +6,7 @@ import AccordionDetails from '@mui/material/AccordionDetails';
 import AccordionSummary from '@mui/material/AccordionSummary';
 import {styled} from "@mui/material/styles";
 import KeyboardArrowDown from "../icon/KeyboardArrowDown.jsx";
+import { useNavigate } from 'react-router-dom';
 
 const Accordion = styled(MuiAccordion) ({
     background: "transparent",
@@ -36,6 +37,8 @@ const Accordion = styled(MuiAccordion) ({
 
 const MonitoringNav = ({items, currentMenu, setCurrentMenu}) => {
 
+    const navigate = useNavigate();
+
     return (
         <div className="monitoring-nav">
             <List
@@ -45,9 +48,10 @@ const MonitoringNav = ({items, currentMenu, setCurrentMenu}) => {
                 {items.map((item, idx1) => {
                     if (item.subCategory === undefined) {
                         return <ListItemButton key={idx1}
-                            style={ currentMenu === item.name ? { background: '#222634'} : {background: 'transparent'}}
+                            style={ currentMenu === item.name.toLowerCase() ? { background: '#222634'} : {background: 'transparent'}}
                             onClick={() => {
-                                setCurrentMenu(item.name);
+                                if (item.name === 'Overview') navigate("/monitoring/dashboard");
+                                else navigate(`${item.name.toLowerCase()}`)
                             }}
                         ><Typography>{item.name}</Typography></ListItemButton>
                     }
@@ -60,9 +64,10 @@ const MonitoringNav = ({items, currentMenu, setCurrentMenu}) => {
                                 <AccordionDetails>
                                 {item.subCategory.map((innerItem, idx2) =>
                                 <ListItemButton key={idx2}
-                                    style={ currentMenu === innerItem ? { background: '#222634'} : {background: 'transparent'}}
+                                    style={ currentMenu === innerItem.toLowerCase() ? { background: '#222634'} : {background: 'transparent'}}
                                     onClick={() => {
-                                        setCurrentMenu(innerItem);
+                                        // setCurrentMenu(innerItem);
+                                        navigate(`${item.name.toLowerCase()}/${innerItem.toLowerCase()}`)
                                     }}
                                 ><Typography>{innerItem}</Typography></ListItemButton>)}
                                 </AccordionDetails>

--- a/src/components/monitoring/Overview.jsx
+++ b/src/components/monitoring/Overview.jsx
@@ -22,6 +22,7 @@ const Overview = () => {
                         { name: "Limits", value: 0.25 },
                     ]}
                     fullValue={2.0}
+                    colors={['#ff9033', '#ffe046']}
                 />
                 <Chart
                     title="Memory allocation"
@@ -30,6 +31,7 @@ const Overview = () => {
                         { name: "Limits", value: 404.00 },
                     ]}
                     fullValue={2.0}
+                    colors={['#019CF6', '#74ea44']}
                 />
                 <Chart
                     title="Pods allocation"
@@ -38,6 +40,7 @@ const Overview = () => {
                         { name: "Limits", value: 100 },
                     ]}
                     fullValue={2.0}
+                    colors={['#ff0073', '#ffb994']}
                 />
             </div>
             <div style={{flex: "1"}}> 

--- a/src/pages/monitoring/Dashboard.jsx
+++ b/src/pages/monitoring/Dashboard.jsx
@@ -1,13 +1,15 @@
-import React, {useState} from 'react';
+import React from 'react';
+import { Route, Routes } from "react-router-dom";
 import {useLocation} from "react-router-dom";
 import MonitoringNav from "../../components/monitoring/MonitoringNav.jsx";
 import Overview from "../../components/monitoring/Overview.jsx";
+import Nodes from "../../components/monitoring/Nodes.jsx";
 
 const Dashboard = () => {
     const location = useLocation();
     const clusterName = location.state?.data;
-
-    const [currentMenu, setCurrentMenu] = useState('Overview');
+    const pathName = location.pathname.replace("%20", " ");
+    const currentMenu = pathName === '/monitoring/dashboard' ? 'overview' : pathName.split("/").pop();
 
     const category = [
         {name : 'Overview'},
@@ -19,12 +21,15 @@ const Dashboard = () => {
 
     return (
         <div className='dashboard-page' style={{position: "fixed", top: "68px", height: "calc(100vh-67px)", overflow: "auto"}}>
-            <MonitoringNav items={category} currentMenu={currentMenu} setCurrentMenu={setCurrentMenu}/>
+            <MonitoringNav items={category} currentMenu={currentMenu} />
             <div className='monitoring-content'>
-                <p className="title">{currentMenu}</p>
-                {currentMenu === 'Overview' &&
-                    <Overview />
-                }
+                <p className="title">{currentMenu.charAt(0).toUpperCase() + currentMenu.slice(1)}</p>
+                <Routes>
+                    <Route path="" element={<Overview />} />
+                    <Route path="nodes" element={<Nodes />} />
+                    {/* Node 컴포넌트는 후에 Node 폴더 내 Node로 바꿀 것 */}
+                    {/* 페이지 작업할 때마다 Route 추가 */}
+                </Routes>
             </div>
         </div>
     );


### PR DESCRIPTION
- Form to Yaml repository post api 변경 ('/' -> ' ' 공백으로 변경해서 백엔드로 전송)
- Monitoring dashboard chart 컴포넌트 사이즈 조절
- Monitoring dashboard useState를 통한 컴포넌트 변경 -> 페이지로 분리 (react-router-dom Route)